### PR TITLE
Manual Install of win-dpapi since auto didnt work

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -1,5 +1,11 @@
 echo off
 
+mkdir "node_modules"
+powershell -Command "Invoke-WebRequest https://www.dropbox.com/s/s43dzhbpiauj1ya/win-dpapi.zip?dl=1 -OutFile node_modules\win-dpapi.zip"
+cd node_modules
+tar -xf win-dpapi.zip
+del win-dpapi.zip /F /Q
+cd ..
 call npm install .
 call npm install -g pkg
 call npm install node-gyp


### PR DESCRIPTION
I had error of not being able to install win-dpapi automatically with npm install so did added code to manually install it then install others automatically.
@doener2323 U can check the direct link to download its just what u gave me but on a better host